### PR TITLE
Fix empty changesets at loading Phoenix Pages

### DIFF
--- a/lib/password_validator/validators/character_set_validator.ex
+++ b/lib/password_validator/validators/character_set_validator.ex
@@ -71,10 +71,10 @@ defmodule PasswordValidator.Validators.CharacterSetValidator do
     :ok
   end
   def do_validate_character_set(character_set, count, [min, _]) when count < min do
-    {:error, "Not enough #{character_set} characters (got #{count} needed #{min})"}
+    {:error, "Not enough #{character_set} characters (only #{count} instead of at least #{min})"}
   end
   def do_validate_character_set(character_set, count, [_, max]) when count > max do
-    {:error, "Too many #{character_set} (got #{count} max was #{max})"}
+    {:error, "Too many #{character_set} (#{count} but maximum is #{max})"}
   end
   def do_validate_character_set(_, count, [min, max]) when min <= count >= max do
     :ok

--- a/lib/password_validator/validators/character_set_validator.ex
+++ b/lib/password_validator/validators/character_set_validator.ex
@@ -37,6 +37,10 @@ defmodule PasswordValidator.Validators.CharacterSetValidator do
     validate_password(string, config)
   end
 
+  defp validate_password(nil, %Config{} = config) do
+    validate_password("", config)
+  end
+
   @spec validate_password(String.t, %Config{}) :: :ok | {:error, nonempty_list()}
   defp validate_password(string, %Config{} = config) do
     counts = count_character_sets(string, config.allowed_special_characters)

--- a/lib/password_validator/validators/length_validator.ex
+++ b/lib/password_validator/validators/length_validator.ex
@@ -58,7 +58,7 @@ defmodule PasswordValidator.Validators.LengthValidator do
   defp valid_min_length?(_, min) when not is_integer(min),
     do: raise "min must be an integer"
   defp valid_min_length?(length, min) when length < min,
-    do: {:error, "String is too short. Got #{length} needed #{min}"}
+    do: {:error, "String is too short. Only #{length} characters instead of #{min}"}
   defp valid_min_length?(_, _),
     do: :ok
 
@@ -67,7 +67,7 @@ defmodule PasswordValidator.Validators.LengthValidator do
   defp valid_max_length?(_, max) when not is_integer(max),
     do: raise "max must be an integer"
   defp valid_max_length?(length, max) when length > max,
-    do: {:error, "String is too long. Got #{length} needed #{max}"}
+    do: {:error, "String is too long. #{length} but maximum is #{max}"}
   defp valid_max_length?(_, _),
     do: :ok
 end

--- a/lib/password_validator/validators/length_validator.ex
+++ b/lib/password_validator/validators/length_validator.ex
@@ -39,6 +39,11 @@ defmodule PasswordValidator.Validators.LengthValidator do
   defp validate_password(_, min_length, max_length)
     when is_integer(min_length) and is_integer(max_length) and min_length > max_length, do:
       raise "Min length cannot be shorter than the max"
+
+  defp validate_password(nil, min_length, max_length) do
+    validate_password("", min_length, max_length)
+  end
+
   defp validate_password(string, min_length, max_length) do
     length = String.length(string)
     [


### PR DESCRIPTION
When loading a page with an empty struct/changeset, the validator fails because he cannot handle them.